### PR TITLE
Soft delete filter for find queries

### DIFF
--- a/ScientificBit.MongoDb/Abstractions/Db/IMongoDbContext.cs
+++ b/ScientificBit.MongoDb/Abstractions/Db/IMongoDbContext.cs
@@ -19,9 +19,10 @@ public interface IMongoDbContext
     Task<bool> IsReplicaSetAsync();
 
     /// <summary>
-    /// Starts MongoDB session
+    /// Starts a MongoDB session
     /// </summary>
     /// <returns></returns>
+    [Obsolete("Use BaseRepository.StartTransactionAsync instead")]
     IClientSessionHandle StartSession();
 
     /// <summary>

--- a/ScientificBit.MongoDb/Abstractions/Repositories/IBaseRepository.cs
+++ b/ScientificBit.MongoDb/Abstractions/Repositories/IBaseRepository.cs
@@ -15,11 +15,19 @@ namespace ScientificBit.MongoDb.Abstractions.Repositories;
 public interface IBaseRepository<TEntity> where TEntity : BaseEntity
 {
     /// <summary>
-    /// Get Document 
+    /// Get a document by ID
     /// </summary>
     /// <param name="documentId"></param>
     /// <returns></returns>
     Task<TEntity?> GetAsync(string documentId);
+
+    /// <summary>
+    /// Get a document by ID in a given session
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="documentId"></param>
+    /// <returns></returns>
+    Task<TEntity?> GetAsync(IClientSessionHandle? session, string documentId);
 
     /// <summary>
     /// Find one document with a given sort key or default sort key, i-e `_id`
@@ -30,12 +38,31 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<TEntity?> FindOneAsync(Expression<Func<TEntity, bool>> expr, string? orderBy = null);
 
     /// <summary>
+    /// Find one document with a given sort key or default sort key, i-e `_id`
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <param name="orderBy"></param>
+    /// <returns></returns>
+    Task<TEntity?> FindOneAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr,
+        string? orderBy = null);
+
+    /// <summary>
     /// Find one document with a given sort definition
     /// </summary>
     /// <param name="expr"></param>
     /// <param name="sort"></param>
     /// <returns></returns>
     Task<TEntity?> FindOneAsync(Expression<Func<TEntity, bool>> expr, SortDefinition<TEntity> sort);
+
+    /// <summary>
+    /// Find one document with a given sort definition
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <param name="sort"></param>
+    /// <returns></returns>
+    Task<TEntity?> FindOneAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr, SortDefinition<TEntity> sort);
 
     /// <summary>
     /// Find one document with a given sort key or default sort key, i-e `_id`
@@ -46,12 +73,32 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<TEntity?> FindOneAsync(FilterDefinition<TEntity> filter, string? orderBy = null);
 
     /// <summary>
+    /// Find one document with a given sort key or default sort key, i-e `_id`
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filter"></param>
+    /// <param name="orderBy"></param>
+    /// <returns></returns>
+    Task<TEntity?> FindOneAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        string? orderBy = null);
+
+    /// <summary>
     /// Find one document with a given sort definition
     /// </summary>
     /// <param name="filter"></param>
     /// <param name="sort"></param>
     /// <returns></returns>
     Task<TEntity?> FindOneAsync(FilterDefinition<TEntity> filter, SortDefinition<TEntity> sort);
+
+    /// <summary>
+    /// Find one document with a given sort definition
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filter"></param>
+    /// <param name="sort"></param>
+    /// <returns></returns>
+    Task<TEntity?> FindOneAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        SortDefinition<TEntity> sort);
 
     /// <summary>
     /// Find all documents matching the given expression
@@ -63,6 +110,18 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     /// <returns></returns>
     Task<IListViewModel<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expr, int? offset, int? limit,
         string? orderBy = null);
+
+    /// <summary>
+    /// Find all documents matching the given expression
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <param name="offset"></param>
+    /// <param name="limit"></param>
+    /// <param name="orderBy"></param>
+    /// <returns></returns>
+    Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr,
+        int? offset, int? limit, string? orderBy = null);
 
     /// <summary>
     /// Find all documents matching the given expression
@@ -76,8 +135,20 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
         SortDefinition<TEntity> sort);
 
     /// <summary>
+    /// Find all documents matching the given expression
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <param name="offset"></param>
+    /// <param name="limit"></param>
+    /// <param name="sort"></param>
+    /// <returns></returns>
+    Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr,
+        int? offset, int? limit, SortDefinition<TEntity> sort);
+
+    /// <summary>
     /// Find all documents matching the given list of filter definitions.
-    /// All filters are combined using AND logic 
+    /// All filters are combined using AND logic
     /// </summary>
     /// <param name="filters"></param>
     /// <param name="offset"></param>
@@ -86,6 +157,20 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     /// <returns></returns>
     Task<IListViewModel<TEntity>> FindAsync(IList<FilterDefinition<TEntity>> filters, int? offset, int? limit,
         string? orderBy = null);
+
+    /// <summary>
+    /// Find all documents matching the given list of filter definitions.
+    /// All filters are combined using AND logic
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filters"></param>
+    /// <param name="offset"></param>
+    /// <param name="limit"></param>
+    /// <param name="orderBy"></param>
+    /// <returns></returns>
+    Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        IList<FilterDefinition<TEntity>> filters,
+        int? offset, int? limit, string? orderBy = null);
 
     /// <summary>
     /// Find all documents matching the given list of filter definitions.
@@ -100,6 +185,20 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
         SortDefinition<TEntity> sort);
 
     /// <summary>
+    /// Find all documents matching the given list of filter definitions.
+    /// All filters are combined using AND logic
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filters"></param>
+    /// <param name="offset"></param>
+    /// <param name="limit"></param>
+    /// <param name="sort"></param>
+    /// <returns></returns>
+    Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        IList<FilterDefinition<TEntity>> filters,
+        int? offset, int? limit, SortDefinition<TEntity> sort);
+
+    /// <summary>
     /// Find all documents matching the given filter definition
     /// </summary>
     /// <param name="filter"></param>
@@ -113,6 +212,18 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     /// <summary>
     /// Find all documents matching the given filter definition
     /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filter"></param>
+    /// <param name="offset"></param>
+    /// <param name="limit"></param>
+    /// <param name="orderBy"></param>
+    /// <returns></returns>
+    Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        int? offset, int? limit, string? orderBy = null);
+
+    /// <summary>
+    /// Find all documents matching the given filter definition
+    /// </summary>
     /// <param name="filter"></param>
     /// <param name="offset"></param>
     /// <param name="limit"></param>
@@ -120,6 +231,18 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     /// <returns></returns>
     Task<IListViewModel<TEntity>> FindAsync(FilterDefinition<TEntity> filter, int? offset, int? limit,
         SortDefinition<TEntity> sort);
+
+    /// <summary>
+    /// Find all documents matching the given filter definition
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filter"></param>
+    /// <param name="offset"></param>
+    /// <param name="limit"></param>
+    /// <param name="sort"></param>
+    /// <returns></returns>
+    Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        int? offset, int? limit, SortDefinition<TEntity> sort);
 
     /// <summary>
     /// Find all documents matching the given filters
@@ -130,12 +253,32 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<IListViewModel<TEntity>> FindAsync(IList<FilterDefinition<TEntity>> filters, FindOptions<TEntity> options);
 
     /// <summary>
+    /// Find all documents matching the given filters
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filters"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session, IList<FilterDefinition<TEntity>> filters,
+        FindOptions<TEntity> options);
+
+    /// <summary>
     /// Find all documents matching the given expression
     /// </summary>
     /// <param name="expr"></param>
     /// <param name="options"></param>
     /// <returns></returns>
     Task<IListViewModel<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expr, FindOptions<TEntity> options);
+
+    /// <summary>
+    /// Find all documents matching the given expression
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr,
+        FindOptions<TEntity> options);
 
     /// <summary>
     /// Find all documents matching the given filter definition
@@ -146,6 +289,16 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<IListViewModel<TEntity>> FindAsync(FilterDefinition<TEntity> filter, FindOptions<TEntity> options);
 
     /// <summary>
+    /// Find all documents matching the given filter definition
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filter"></param>
+    /// <param name="options"></param>
+    /// <returns></returns>
+    Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        FindOptions<TEntity> options);
+
+    /// <summary>
     /// Count all documents matching this given filter expression
     /// </summary>
     /// <param name="expr"></param>
@@ -153,11 +306,27 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<long> CountDocumentsAsync(Expression<Func<TEntity, bool>> expr);
 
     /// <summary>
+    /// Count all documents matching this given filter expression
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <returns></returns>
+    Task<long> CountDocumentsAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr);
+
+    /// <summary>
     /// Count all documents matching this given filter definition
     /// </summary>
     /// <param name="filter"></param>
     /// <returns></returns>
     Task<long> CountDocumentsAsync(FilterDefinition<TEntity> filter);
+
+    /// <summary>
+    /// Count all documents matching this given filter definition
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filter"></param>
+    /// <returns></returns>
+    Task<long> CountDocumentsAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter);
 
     /// <summary>
     /// Equivalent to collection.findOneAndUpdate method. The update definition is generated
@@ -177,6 +346,20 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     /// automatically based on TUpdateModel fields.
     /// All `null` values are ignored in TUpdateModel instance
     /// </summary>
+    /// <param name="session"></param>
+    /// <param name="documentId"></param>
+    /// <param name="payload"></param>
+    /// <param name="returnUpdated"></param>
+    /// <typeparam name="TUpdateModel"></typeparam>
+    /// <returns></returns>
+    Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(IClientSessionHandle? session, string documentId,
+        TUpdateModel payload, bool returnUpdated = true) where TUpdateModel : IUpdateModel;
+
+    /// <summary>
+    /// Equivalent to collection.findOneAndUpdate method. The update definition is generated
+    /// automatically based on TUpdateModel fields.
+    /// All `null` values are ignored in TUpdateModel instance
+    /// </summary>
     /// <param name="expr"></param>
     /// <param name="payload"></param>
     /// <param name="isUpsert"></param>
@@ -187,6 +370,23 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
         bool isUpsert, bool returnUpdated = true)  where TUpdateModel : IUpdateModel;
 
     /// <summary>
+    /// Equivalent to collection.findOneAndUpdate method. The update definition is generated
+    /// automatically based on TUpdateModel fields.
+    /// All `null` values are ignored in TUpdateModel instance
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <param name="payload"></param>
+    /// <param name="isUpsert"></param>
+    /// <param name="returnUpdated"></param>
+    /// <typeparam name="TUpdateModel"></typeparam>
+    /// <returns></returns>
+    Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(IClientSessionHandle? session,
+        Expression<Func<TEntity, bool>> expr,
+        TUpdateModel payload,
+        bool isUpsert, bool returnUpdated = true) where TUpdateModel : IUpdateModel;
+
+    /// <summary>
     /// Create a single document
     /// </summary>
     /// <param name="document"></param>
@@ -194,11 +394,27 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task CreateAsync(TEntity document);
 
     /// <summary>
-    /// Creates given list of documents.
+    /// Create a single document
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="document"></param>
+    /// <returns></returns>
+    Task CreateAsync(IClientSessionHandle? session, TEntity document);
+
+    /// <summary>
+    /// Creates the given list of documents.
     /// </summary>
     /// <param name="documents"></param>
     /// <returns></returns>
     Task CreateManyAsync(IList<TEntity> documents);
+
+    /// <summary>
+    /// Creates the given list of documents.
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="documents"></param>
+    /// <returns></returns>
+    Task CreateManyAsync(IClientSessionHandle? session, IList<TEntity> documents);
 
     /// <summary>
     /// Updates a single document. The update definition is generated
@@ -215,11 +431,36 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     /// automatically based on TUpdateModel fields.
     /// All `null` values are ignored in TUpdateModel instance
     /// </summary>
+    /// <param name="session"></param>
+    /// <param name="payload"></param>
+    /// <typeparam name="TUpdateModel"></typeparam>
+    /// <returns></returns>
+    Task<DbResult> UpdateAsync<TUpdateModel>(IClientSessionHandle? session, TUpdateModel payload)
+        where TUpdateModel : IUpdateModel;
+
+    /// <summary>
+    /// Updates a single document. The update definition is generated
+    /// automatically based on TUpdateModel fields.
+    /// All `null` values are ignored in TUpdateModel instance
+    /// </summary>
     /// <param name="documentId"></param>
     /// <param name="payload"></param>
     /// <typeparam name="TUpdateModel"></typeparam>
     /// <returns></returns>
     Task<DbResult> UpdateAsync<TUpdateModel>(string documentId, TUpdateModel payload) where TUpdateModel : IUpdateModel;
+
+    /// <summary>
+    /// Updates a single document. The update definition is generated
+    /// automatically based on TUpdateModel fields.
+    /// All `null` values are ignored in TUpdateModel instance
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="documentId"></param>
+    /// <param name="payload"></param>
+    /// <typeparam name="TUpdateModel"></typeparam>
+    /// <returns></returns>
+    Task<DbResult> UpdateAsync<TUpdateModel>(IClientSessionHandle? session, string documentId, TUpdateModel payload)
+        where TUpdateModel : IUpdateModel;
 
     /// <summary>
     /// Updated documents matching the filter expression. The update definition is generated
@@ -235,6 +476,21 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
         bool updateMany) where TUpdateModel : IUpdateModel;
 
     /// <summary>
+    /// Updated documents matching the filter expression. The update definition is generated
+    /// automatically based on TUpdateModel fields.
+    /// All `null` values are ignored in TUpdateModel instance
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <param name="payload"></param>
+    /// <param name="updateMany"></param>
+    /// <typeparam name="TUpdateModel"></typeparam>
+    /// <returns></returns>
+    Task<DbResult> UpdateAsync<TUpdateModel>(IClientSessionHandle? session,
+        Expression<Func<TEntity, bool>> expr, TUpdateModel payload,
+        bool updateMany) where TUpdateModel : IUpdateModel;
+
+    /// <summary>
     /// Update documents in bulk. `IUpdateModel.Id` filed is used to match documents.
     /// </summary>
     /// <param name="updates"></param>
@@ -244,9 +500,9 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
         where TUpdateModel : IUpdateModel;
 
     /// <summary>
-    /// Deletes a document with given ID.
-    /// Deleting documents just updates `DeletedAt` property. To delete documents permanently, set
-    /// pass `permanent = true` to this function 
+    /// Deletes a document with a given I D.
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
     /// </summary>
     /// <param name="documentId"></param>
     /// <param name="permanent"></param>
@@ -254,9 +510,20 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<TEntity?> FindOneAndDeleteAsync(string documentId, bool permanent = false);
 
     /// <summary>
+    /// Deletes a document with a given I D.
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="documentId"></param>
+    /// <param name="permanent"></param>
+    /// <returns></returns>
+    Task<TEntity?> FindOneAndDeleteAsync(IClientSessionHandle? session, string documentId, bool permanent = false);
+
+    /// <summary>
     /// Deletes a document matching the filter expression
-    /// Deleting documents just updates `DeletedAt` property. To delete documents permanently, set
-    /// pass `permanent = true` to this function 
+    /// Deleting the document just updates `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
     /// </summary>
     /// <param name="expr"></param>
     /// <param name="permanent"></param>
@@ -264,9 +531,21 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<TEntity?> FindOneAndDeleteAsync(Expression<Func<TEntity, bool>> expr, bool permanent = false);
 
     /// <summary>
+    /// Deletes a document matching the filter expression
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <param name="permanent"></param>
+    /// <returns></returns>
+    Task<TEntity?> FindOneAndDeleteAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr,
+        bool permanent = false);
+
+    /// <summary>
     /// Deletes a document matching the filter expression.
-    /// Deleting documents just updates `DeletedAt` property. To delete documents permanently, set
-    /// pass `permanent = true` to this function 
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
     /// </summary>
     /// <param name="filter"></param>
     /// <param name="permanent"></param>
@@ -274,9 +553,21 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<TEntity?> FindOneAndDeleteAsync(FilterDefinition<TEntity> filter, bool permanent = false);
 
     /// <summary>
+    /// Deletes a document matching the filter expression.
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filter"></param>
+    /// <param name="permanent"></param>
+    /// <returns></returns>
+    Task<TEntity?> FindOneAndDeleteAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        bool permanent = false);
+
+    /// <summary>
     /// Deletes a document with given ID.
-    /// Deleting documents just updates `DeletedAt` property. To delete documents permanently, set
-    /// pass `permanent = true` to this function 
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
     /// </summary>
     /// <param name="documentId"></param>
     /// <param name="permanent"></param>
@@ -284,9 +575,20 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<DbResult> DeleteOneAsync(string documentId, bool permanent = false);
 
     /// <summary>
+    /// Deletes a document with given ID.
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="documentId"></param>
+    /// <param name="permanent"></param>
+    /// <returns></returns>
+    Task<DbResult> DeleteOneAsync(IClientSessionHandle? session, string documentId, bool permanent = false);
+
+    /// <summary>
     /// Deletes all documents matching the given filter expression
-    /// Deleting documents just updates `DeletedAt` property. To delete documents permanently, set
-    /// pass `permanent = true` to this function 
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
     /// </summary>
     /// <param name="expr"></param>
     /// <param name="permanent"></param>
@@ -294,14 +596,37 @@ public interface IBaseRepository<TEntity> where TEntity : BaseEntity
     Task<DbResult> DeleteAsync(Expression<Func<TEntity, bool>> expr, bool permanent = false);
 
     /// <summary>
+    /// Deletes all documents matching the given filter expression
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="expr"></param>
+    /// <param name="permanent"></param>
+    /// <returns></returns>
+    Task<DbResult> DeleteAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr,
+        bool permanent = false);
+
+    /// <summary>
     /// Deletes all documents matching the given filter definition
-    /// Deleting documents just updates `DeletedAt` property. To delete documents permanently, set
-    /// pass `permanent = true` to this function 
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
     /// </summary>
     /// <param name="filter"></param>
     /// <param name="permanent"></param>
     /// <returns></returns>
     Task<DbResult> DeleteAsync(FilterDefinition<TEntity> filter, bool permanent = false);
+
+    /// <summary>
+    /// Deletes all documents matching the given filter definition
+    /// If soft delete is supported, it just updates the `DeletedAt` property. To delete documents permanently, set
+    /// pass `permanent = true` to this function
+    /// </summary>
+    /// <param name="session"></param>
+    /// <param name="filter"></param>
+    /// <param name="permanent"></param>
+    /// <returns></returns>
+    Task<DbResult> DeleteAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter, bool permanent = false);
 
     /// <summary>
     /// Generate an auto-increment ID for underlying entity

--- a/ScientificBit.MongoDb/Builders/FiltersBuilder.cs
+++ b/ScientificBit.MongoDb/Builders/FiltersBuilder.cs
@@ -21,11 +21,7 @@ public static class FiltersBuilder<TEntity>
             throw new ArgumentException($"Invalid document Id ({documentId})");
         }
 
-        return And(new List<FilterDefinition<TEntity>>
-        {
-            Builders<TEntity>.Filter.Eq(nameof(BaseEntity.Id), documentId),
-            GetDeleteAtFilter()
-        });
+        return Builders<TEntity>.Filter.Eq(nameof(BaseEntity.Id), documentId);
     }
 
     public static FilterDefinition<TEntity> And(IList<FilterDefinition<TEntity>> filters)
@@ -40,10 +36,10 @@ public static class FiltersBuilder<TEntity>
         return filters.Count == 1 ? filters[0] : Builders<TEntity>.Filter.Or(filters);
     }
 
-    public static FilterDefinition<TEntity> GetDeleteAtFilter()
-    {
-        return Builders<TEntity>.Filter.Eq(nameof(BaseEntity.DeletedAt), BsonNull.Value);
-    }
+    // public static FilterDefinition<TEntity> GetDeleteAtFilter()
+    // {
+    //     return Builders<TEntity>.Filter.Eq(nameof(BaseEntity.DeletedAt), BsonNull.Value);
+    // }
 
     public static FilterDefinition<TEntity>? GetTextSearchFilter(string? value)
     {

--- a/ScientificBit.MongoDb/Configuration/MongoDbContext.cs
+++ b/ScientificBit.MongoDb/Configuration/MongoDbContext.cs
@@ -45,7 +45,7 @@ public class MongoDbContext : IMongoDbContext
         var models = indexModels.ToList();
         if (models.Count > 0)
         {
-            collection.Indexes.CreateManyAsync(models).GetAwaiter().GetResult();
+            collection.Indexes.CreateManyAsync(models).ConfigureAwait(false).GetAwaiter().GetResult();
         }
 
         _indexesCreated.TryAdd(collection.CollectionNamespace.CollectionName, true);

--- a/ScientificBit.MongoDb/Entities/BaseEntity.cs
+++ b/ScientificBit.MongoDb/Entities/BaseEntity.cs
@@ -5,10 +5,6 @@ namespace ScientificBit.MongoDb.Entities;
 
 public abstract class BaseEntity
 {
-    protected BaseEntity()
-    {
-    }
-    
     /// <summary>
     /// Gets or sets the Id of the Entity.
     /// </summary>
@@ -21,7 +17,7 @@ public abstract class BaseEntity
 
     public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
 
-    public DateTime? DeletedAt { get; set; }
+    // public DateTime? DeletedAt { get; set; }
 
     public virtual void Validate()
     {

--- a/ScientificBit.MongoDb/README.md
+++ b/ScientificBit.MongoDb/README.md
@@ -3,6 +3,22 @@ The package implements a repository layer over MongoDB collections.
 Developers can easily define CRUD operations on a Collection by just
 deriving their collection-wise repository classes from `BaseRepository` class.
 
+# Release Notes
+## v3.0.0 (Release Date: 2025-08-11)
+### Changes and Fixes
+* Introduced `FindOneAsync` methods variants in `BaseRepository` class to find a single document by filter or by id.
+* Added `BaseRepository` method variants to accept `IClientSessionHandle` for operations that require a session.
+* **DEPRECATION:** `StartSession` method in `IMongoDbContext` is now deprecated. Use `BaseRepository.StartTransactionAsync` instead.
+### Breaking Changes
+* Removed `DeletedAt` field from `BaseEntity` class. If you want to support
+  soft deletes, you can just define a `DeletedAt` field in your entity model.
+* Removed `GetDeleteAtFilter` method from `FiltersBuilder` class.
+
+## v2.2.3 (Release Date: 2025-08-10)
+### Changes and Fixes
+* **BUG FIX**: `CreateIndexes` method in `IMongoDbContext` now awaits for index creation to complete before returning.
+* **BREAKING CHANGE:** Since `CreateIndexes` is no more fire-and-forget, it may break existing code that relies on the previous behavior. Ensure to handle the asynchronous nature of this method in your code.
+
 ## How to Integrate
 The package is built for .NET 8, 9 and supports MongoDB v6+. 
 

--- a/ScientificBit.MongoDb/Repositories/BaseRepository.cs
+++ b/ScientificBit.MongoDb/Repositories/BaseRepository.cs
@@ -11,6 +11,7 @@ using ScientificBit.MongoDb.Mongo;
 using ScientificBit.MongoDb.Updates;
 using ScientificBit.MongoDb.Views;
 using ScientificBit.MongoDb.Extensions;
+using ScientificBit.MongoDb.Utils;
 
 namespace ScientificBit.MongoDb.Repositories;
 
@@ -24,17 +25,21 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
     private readonly ILogger? _logger;
 
     private const int DefaultLimit = 50;
+    private const string SoftDeleteFieldName = "DeletedAt";
+
+    protected virtual bool SupportsSoftDelete => typeof(TEntity).GetProperties()
+        .Any(p => p.Name.Equals(SoftDeleteFieldName, StringComparison.OrdinalIgnoreCase));
 
     protected BaseRepository(IMongoDbContext dbContext) : this(null, dbContext)
     {
     }
 
     /// <summary>
-    /// Override this constructor, if you want to pass ILogger
+    /// Override this constructor if you want to pass ILogger
     /// </summary>
     /// <param name="logger"></param>
     /// <param name="dbContext"></param>
-    protected BaseRepository(ILogger? logger, IMongoDbContext dbContext) : base(dbContext)
+    protected BaseRepository(ILogger? logger, IMongoDbContext dbContext) : base(logger, dbContext)
     {
         _logger = logger;
     }
@@ -44,126 +49,236 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
         var builder = Builders<TEntity>.IndexKeys;
         var indexModels = new List<CreateIndexModel<TEntity>>
         {
-            new (builder.Descending(doc => doc.UpdatedAt), new CreateIndexOptions { Background = true }),
-            new (builder.Descending(doc => doc.CreatedAt), new CreateIndexOptions { Background = true }),
-            new (builder.Ascending(doc => doc.DeletedAt), new CreateIndexOptions { Background = true })
+            new(builder.Descending(doc => doc.UpdatedAt), new CreateIndexOptions { Background = true }),
+            new(builder.Descending(doc => doc.CreatedAt), new CreateIndexOptions { Background = true })
         };
+        if (SupportsSoftDelete)
+        {
+            indexModels.Add(new CreateIndexModel<TEntity>(builder.Ascending(SoftDeleteFieldName),
+                new CreateIndexOptions { Background = true }));
+        }
+
         return indexModels;
     }
 
-    public virtual Task<TEntity?> GetAsync(string documentId)
+    public virtual async Task<TEntity?> GetAsync(string documentId)
+    {
+        return await GetAsync(null, documentId);
+    }
+
+    public virtual async Task<TEntity?> GetAsync(IClientSessionHandle? session, string documentId)
     {
         AssertObjectId(documentId);
-        return FindOneAsync(FiltersBuilder<TEntity>.GetIdFilter(documentId));
+        return await FindOneAsync(session, FiltersBuilder<TEntity>.GetIdFilter(documentId));
     }
 
-    public Task<TEntity?> FindOneAsync(Expression<Func<TEntity, bool>> expr)
+    public async Task<TEntity?> FindOneAsync(Expression<Func<TEntity, bool>> expr)
     {
-        return FindOneAsync(expr, orderBy: null);
+        return await FindOneAsync(null, expr);
     }
 
-    public Task<TEntity?> FindOneAsync(Expression<Func<TEntity, bool>> expr, string? orderBy)
+    public async Task<TEntity?> FindOneAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr)
     {
-        return FindOneAsync((FilterDefinition<TEntity>) expr, orderBy);
+        return await FindOneAsync(session, expr, orderBy: null);
     }
 
-    public Task<TEntity?> FindOneAsync(Expression<Func<TEntity, bool>> expr, SortDefinition<TEntity> sort)
+    public async Task<TEntity?> FindOneAsync(Expression<Func<TEntity, bool>> expr, string? orderBy)
     {
-        return FindOneAsync((FilterDefinition<TEntity>) expr, sort);
+        return await FindOneAsync(null, expr, orderBy);
     }
 
-    public Task<TEntity?> FindOneAsync(FilterDefinition<TEntity> filter)
+    public async Task<TEntity?> FindOneAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr,
+        string? orderBy)
     {
-        return FindOneAsync(filter, orderBy: null);
+        return await FindOneAsync(session, (FilterDefinition<TEntity>) expr, orderBy);
+    }
+
+    public async Task<TEntity?> FindOneAsync(Expression<Func<TEntity, bool>> expr, SortDefinition<TEntity> sort)
+    {
+        return await FindOneAsync(null, expr, sort);
+    }
+
+    public async Task<TEntity?> FindOneAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr,
+        SortDefinition<TEntity> sort)
+    {
+        return await FindOneAsync(session, (FilterDefinition<TEntity>) expr, sort);
+    }
+
+    public async Task<TEntity?> FindOneAsync(FilterDefinition<TEntity> filter)
+    {
+        return await FindOneAsync(session: null, filter);
+    }
+
+    public async Task<TEntity?> FindOneAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter)
+    {
+        return await FindOneAsync(session, filter, orderBy: null);
     }
 
     public async Task<TEntity?> FindOneAsync(FilterDefinition<TEntity> filter, string? orderBy)
     {
-        var result = await FindAsyncImpl(filter, 0, 1, orderBy);
+        return await FindOneAsync(null, filter, orderBy);
+    }
+
+    public async Task<TEntity?> FindOneAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        string? orderBy)
+    {
+        var result = await FindAsyncImpl(session, filter, 0, 1, orderBy);
         return result.Documents.FirstOrDefault();
     }
 
     public async Task<TEntity?> FindOneAsync(FilterDefinition<TEntity> filter, SortDefinition<TEntity> sort)
     {
-        var result = await FindAsyncImpl(filter, 0, 1, sort);
+        return await FindOneAsync(null, filter, sort);
+    }
+
+    public async Task<TEntity?> FindOneAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        SortDefinition<TEntity> sort)
+    {
+        var result = await FindAsyncImpl(session, filter, 0, 1, sort);
         return result.Documents.FirstOrDefault();
     }
 
-    public Task<long> CountDocumentsAsync(Expression<Func<TEntity, bool>> expr)
+    public async Task<long> CountDocumentsAsync(Expression<Func<TEntity, bool>> expr)
     {
-        return CountDocumentsAsync((FilterDefinition<TEntity>) expr);
+        return await CountDocumentsAsync(null, expr);
+    }
+
+    public async Task<long> CountDocumentsAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr)
+    {
+        return await CountDocumentsAsync(session, (FilterDefinition<TEntity>) expr);
     }
 
     public async Task<long> CountDocumentsAsync(FilterDefinition<TEntity> filter)
     {
-        var result = await Collection.CountDocumentsAsync(filter);
+        return await CountDocumentsAsync(null, filter);
+    }
+
+    public async Task<long> CountDocumentsAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter)
+    {
+        var result = await Collection.CountDocumentsAsync(session, filter);
         return result;
     }
 
-    public Task<IListViewModel<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expr, int? offset, int? limit)
+    public async Task<IListViewModel<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expr, int? offset, int? limit)
     {
-        return FindAsync(expr, offset, limit, orderBy: null);
+        return await FindAsync(expr, offset, limit, orderBy: null);
     }
 
-    public Task<IListViewModel<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expr, int? offset, int? limit,
+    public async Task<IListViewModel<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expr, int? offset, int? limit,
         string? orderBy)
     {
-        return FindAsync((FilterDefinition<TEntity>) expr, offset, limit, orderBy);
+        return await FindAsync(null, expr, offset, limit, orderBy);
     }
 
-    public Task<IListViewModel<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expr, int? offset,  int? limit, SortDefinition<TEntity> sort)
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        Expression<Func<TEntity, bool>> expr,
+        int? offset, int? limit, string? orderBy)
     {
-        return FindAsync((FilterDefinition<TEntity>) expr, offset, limit, sort);
+        return await FindAsync(session, (FilterDefinition<TEntity>) expr, offset, limit, orderBy);
     }
 
-    public Task<IListViewModel<TEntity>> FindAsync(IList<FilterDefinition<TEntity>> filters, int? offset, int? limit)
-    {
-        return FindAsync(filters, offset, limit, orderBy: null);
-    }
-
-    public Task<IListViewModel<TEntity>> FindAsync(IList<FilterDefinition<TEntity>> filters, int? offset, int? limit,
-        string? orderBy)
-    {
-        // Exclude deleted docs
-        filters.Add(FiltersBuilder<TEntity>.GetDeleteAtFilter());
-        return FindAsync(FiltersBuilder<TEntity>.And(filters), offset, limit, orderBy);
-    }
-
-    public Task<IListViewModel<TEntity>> FindAsync(IList<FilterDefinition<TEntity>> filters, int? offset, int? limit,
+    public async Task<IListViewModel<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expr, int? offset, int? limit,
         SortDefinition<TEntity> sort)
     {
-        // Exclude deleted docs
-        filters.Add(FiltersBuilder<TEntity>.GetDeleteAtFilter());
-        return FindAsync(FiltersBuilder<TEntity>.And(filters), offset, limit, sort);
+        return await FindAsync(null, expr, offset, limit, sort);
     }
 
-    public Task<IListViewModel<TEntity>> FindAsync(FilterDefinition<TEntity> filter, int? offset, int? limit)
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        Expression<Func<TEntity, bool>> expr,
+        int? offset, int? limit,
+        SortDefinition<TEntity> sort)
     {
-        return FindAsync(filter, offset, limit, orderBy: null);
+        return await FindAsync(session, (FilterDefinition<TEntity>) expr, offset, limit, sort);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(IList<FilterDefinition<TEntity>> filters, int? offset,
+        int? limit)
+    {
+        return await FindAsync(filters, offset, limit, orderBy: null);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(IList<FilterDefinition<TEntity>> filters,
+        int? offset, int? limit, string? orderBy)
+    {
+        return await FindAsync(null, filters, offset, limit, orderBy);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        IList<FilterDefinition<TEntity>> filters,
+        int? offset, int? limit,
+        string? orderBy)
+    {
+        return await FindAsync(session,FiltersBuilder<TEntity>.And(filters), offset, limit, orderBy);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(IList<FilterDefinition<TEntity>> filters,
+        int? offset, int? limit, SortDefinition<TEntity> sort)
+    {
+        return await FindAsync(null, filters, offset, limit, sort);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        IList<FilterDefinition<TEntity>> filters, int? offset, int? limit,
+        SortDefinition<TEntity> sort)
+    {
+        return await FindAsync(session, FiltersBuilder<TEntity>.And(filters), offset, limit, sort);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(FilterDefinition<TEntity> filter, int? offset, int? limit)
+    {
+        return await FindAsync(null, filter, offset, limit);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        FilterDefinition<TEntity> filter, int? offset, int? limit)
+    {
+        return await FindAsync(session, filter, offset, limit, orderBy: null);
     }
 
     public async Task<IListViewModel<TEntity>> FindAsync(FilterDefinition<TEntity> filter, int? offset, int? limit, string? orderBy)
     {
-        var pageSize = limit ?? DefaultLimit;
-        if(pageSize == -1) pageSize = int.MaxValue; // Removes the limit if -1 is passed
-        var pageOffset = offset ?? 0;
-        return await FindAsyncImpl(filter, pageOffset, pageSize, orderBy);
+        return await FindAsync(null, filter, offset, limit, orderBy);
     }
 
-    public async Task<IListViewModel<TEntity>> FindAsync(FilterDefinition<TEntity> filter, int? offset, int? limit, SortDefinition<TEntity> sort)
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter, int? offset, int? limit, string? orderBy)
+    {
+        var pageSize = limit ?? DefaultLimit;
+        if (pageSize == -1) pageSize = int.MaxValue; // Removes the limit if -1 is passed
+
+        var pageOffset = offset ?? 0;
+
+        return await FindAsyncImpl(session, filter, pageOffset, pageSize, orderBy);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(FilterDefinition<TEntity> filter,
+        int? offset, int? limit,
+        SortDefinition<TEntity> sort)
+    {
+        return await FindAsync(null, filter, offset, limit, sort);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        FilterDefinition<TEntity> filter,
+        int? offset, int? limit,
+        SortDefinition<TEntity> sort)
     {
         var pageSize = limit ?? DefaultLimit;
         if(pageSize == -1) pageSize = int.MaxValue; // Removes the limit if -1 is passed
         var pageOffset = offset ?? 0;
-        return await FindAsyncImpl(filter, pageOffset, pageSize, sort);
+        return await FindAsyncImpl(session, filter, pageOffset, pageSize, sort);
     }
 
     public async Task<IListViewModel<TEntity>> FindAsync(IList<FilterDefinition<TEntity>> filters,
         FindOptions<TEntity> options)
     {
-        // Exclude deleted docs
-        filters.Add(FiltersBuilder<TEntity>.GetDeleteAtFilter());
-        return await FindAsync(FiltersBuilder<TEntity>.And(filters), options);
+        return await FindAsync(null, filters, options);
+    }
+
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        IList<FilterDefinition<TEntity>> filters,
+        FindOptions<TEntity> options)
+    {
+        return await FindAsync(session, FiltersBuilder<TEntity>.And(filters), options);
     }
 
     public async Task<IListViewModel<TEntity>> FindAsync(Expression<Func<TEntity, bool>> expr,
@@ -172,18 +287,33 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
         return await FindAsync((FilterDefinition<TEntity>) expr, options);
     }
 
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        Expression<Func<TEntity, bool>> expr,
+        FindOptions<TEntity> options)
+    {
+        return await FindAsync(session, (FilterDefinition<TEntity>) expr, options);
+    }
+
     public async Task<IListViewModel<TEntity>> FindAsync(FilterDefinition<TEntity> filter, FindOptions<TEntity> options)
     {
-        return await FindAsyncImpl(filter, options);
+        return await FindAsync(null, filter, options);
     }
 
-    public Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(string documentId, TUpdateModel payload)
-        where TUpdateModel : IUpdateModel
+    public async Task<IListViewModel<TEntity>> FindAsync(IClientSessionHandle? session,
+        FilterDefinition<TEntity> filter,
+        FindOptions<TEntity> options)
     {
-        return FindOneAndUpdateAsync(documentId, payload, returnUpdated: true);
+        return await FindAsyncImpl(session, filter, options);
     }
 
-    public virtual Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(string documentId, TUpdateModel payload,
+    public virtual async Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(string documentId, TUpdateModel payload,
+        bool returnUpdated) where TUpdateModel : IUpdateModel
+    {
+        return await FindOneAndUpdateAsync(null, documentId, payload, returnUpdated);
+    }
+
+    public virtual async Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(IClientSessionHandle? session,
+        string documentId, TUpdateModel payload,
         bool returnUpdated) where TUpdateModel : IUpdateModel
     {
         var opts = new FindOneAndUpdateOptions<TEntity>
@@ -193,17 +323,19 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
         };
 
         var filter = FiltersBuilder<TEntity>.GetIdFilter(documentId);
-        return FindOneAndUpdateAsync(filter, payload, opts);
+        return await FindOneAndUpdateAsync(session, filter, payload, opts);
     }
 
-    public Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(Expression<Func<TEntity, bool>> expr,
-        TUpdateModel payload, bool isUpsert) where TUpdateModel : IUpdateModel
-    {
-        return FindOneAndUpdateAsync(expr, payload, isUpsert, returnUpdated: true);
-    }
-
-    public virtual Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(Expression<Func<TEntity, bool>> expr,
+    public virtual async Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(Expression<Func<TEntity, bool>> expr,
         TUpdateModel payload, bool isUpsert, bool returnUpdated) where TUpdateModel : IUpdateModel
+    {
+        return await FindOneAndUpdateAsync(null, expr, payload, isUpsert, returnUpdated);
+    }
+
+    public virtual async Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(IClientSessionHandle? session,
+        Expression<Func<TEntity, bool>> expr,
+        TUpdateModel payload,
+        bool isUpsert, bool returnUpdated) where TUpdateModel : IUpdateModel
     {
         var opts = new FindOneAndUpdateOptions<TEntity>
         {
@@ -211,42 +343,87 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
             IsUpsert = isUpsert
         };
 
-        return FindOneAndUpdateAsync((FilterDefinition<TEntity>)expr, payload, opts);
+        return await FindOneAndUpdateAsync(session, (FilterDefinition<TEntity>)expr, payload, opts);
     }
 
-    public virtual Task CreateAsync(TEntity document)
+    public virtual async Task CreateAsync(TEntity document)
+    {
+        await CreateAsync(session: null, document);
+    }
+
+    public virtual async Task CreateAsync(IClientSessionHandle? session, TEntity document)
     {
         // Validate Input model
         document.Validate();
 
-        return Collection.InsertOneAsync(document);
+        if (session != null)
+        {
+            await Collection.InsertOneAsync(session, document);
+        }
+        else
+        {
+            await Collection.InsertOneAsync(document);
+        }
     }
 
     public virtual async Task CreateManyAsync(IList<TEntity> documents)
     {
+        await CreateManyAsync(null, documents);
+    }
+
+    public virtual async Task CreateManyAsync(IClientSessionHandle? session, IList<TEntity> documents)
+    {
         if (!documents.Any()) return;
         documents.ToList().ForEach(doc => doc.Validate());
 
-        await Collection.InsertManyAsync(documents);
+        if (session != null)
+        {
+            await Collection.InsertManyAsync(session, documents);
+        }
+        else
+        {
+            await Collection.InsertManyAsync(documents);
+        }
     }
 
-    public virtual Task<DbResult> UpdateAsync<TUpdateModel>(TUpdateModel payload) where TUpdateModel : IUpdateModel
-    {
-        AssertObjectId(payload.Id);
-        return UpdateAsync(payload.Id!, payload);
-    }
-
-    public virtual Task<DbResult> UpdateAsync<TUpdateModel>(string documentId, TUpdateModel payload)
+    public virtual async Task<DbResult> UpdateAsync<TUpdateModel>(TUpdateModel payload)
         where TUpdateModel : IUpdateModel
     {
-        AssertObjectId(documentId);
-        return UpdateAsync(FiltersBuilder<TEntity>.GetIdFilter(documentId), payload, false);
+        return await UpdateAsync(session: null, payload);
     }
 
-    public virtual Task<DbResult> UpdateAsync<TUpdateModel>(Expression<Func<TEntity, bool>> expr, TUpdateModel payload,
+    public virtual async Task<DbResult> UpdateAsync<TUpdateModel>(IClientSessionHandle? session,
+        TUpdateModel payload) where TUpdateModel : IUpdateModel
+    {
+        AssertObjectId(payload.Id);
+        return await UpdateAsync(session, payload.Id!, payload);
+    }
+
+    public virtual async Task<DbResult> UpdateAsync<TUpdateModel>(string documentId, TUpdateModel payload)
+        where TUpdateModel : IUpdateModel
+    {
+        return await UpdateAsync(null, documentId, payload);
+    }
+
+    public virtual async Task<DbResult> UpdateAsync<TUpdateModel>(IClientSessionHandle? session, string documentId,
+        TUpdateModel payload) where TUpdateModel : IUpdateModel
+    {
+        AssertObjectId(documentId);
+        return await UpdateAsync(session, FiltersBuilder<TEntity>.GetIdFilter(documentId), payload, false);
+    }
+
+    public virtual async Task<DbResult> UpdateAsync<TUpdateModel>(Expression<Func<TEntity, bool>> expr, TUpdateModel payload,
         bool updateMany) where TUpdateModel : IUpdateModel
     {
-        return UpdateAsync((FilterDefinition<TEntity>) expr, payload, updateMany);
+        return await UpdateAsync(null, expr, payload, updateMany);
+    }
+
+    public virtual async Task<DbResult> UpdateAsync<TUpdateModel>(IClientSessionHandle? session,
+        Expression<Func<TEntity, bool>> expr,
+        TUpdateModel payload,
+        bool updateMany) where TUpdateModel : IUpdateModel
+    {
+        return await UpdateAsync(session, (FilterDefinition<TEntity>) expr, payload, updateMany);
     }
 
     public virtual async Task<BulkWriteResult<TEntity>> BulkUpdateAsync<TUpdateModel>(IList<TUpdateModel> updates)
@@ -272,77 +449,83 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
         return result;
     }
 
-    public Task<TEntity?> FindOneAndDeleteAsync(string documentId)
+    public async Task<TEntity?> FindOneAndDeleteAsync(string documentId, bool permanent)
     {
-        return FindOneAndDeleteAsync(documentId, permanent: false);
+        return await FindOneAndDeleteAsync(null, documentId, permanent);
     }
 
-    public Task<TEntity?> FindOneAndDeleteAsync(string documentId, bool permanent)
+    public async Task<TEntity?> FindOneAndDeleteAsync(IClientSessionHandle? session, string documentId, bool permanent)
     {
         AssertObjectId(documentId);
-        return FindOneAndDeleteAsync(FiltersBuilder<TEntity>.GetIdFilter(documentId), permanent);
+        return await FindOneAndDeleteAsync(session, FiltersBuilder<TEntity>.GetIdFilter(documentId), permanent);
     }
 
-    public Task<TEntity?> FindOneAndDeleteAsync(Expression<Func<TEntity, bool>> expr)
+    public async Task<TEntity?> FindOneAndDeleteAsync(Expression<Func<TEntity, bool>> expr, bool permanent)
     {
-        return FindOneAndDeleteAsync(expr, permanent: false);
+        return await FindOneAndDeleteAsync(null, expr, permanent);
     }
 
-    public Task<TEntity?> FindOneAndDeleteAsync(Expression<Func<TEntity, bool>> expr, bool permanent)
+    public async Task<TEntity?> FindOneAndDeleteAsync(IClientSessionHandle? session,
+        Expression<Func<TEntity, bool>> expr, bool permanent)
     {
-        return FindOneAndDeleteAsync((FilterDefinition<TEntity>) expr, permanent);
-    }
-
-    public Task<TEntity?> FindOneAndDeleteAsync(FilterDefinition<TEntity> filter)
-    {
-        return FindOneAndDeleteAsync(filter, permanent: false);
+        return await FindOneAndDeleteAsync(session, (FilterDefinition<TEntity>) expr, permanent);
     }
 
     public async Task<TEntity?> FindOneAndDeleteAsync(FilterDefinition<TEntity> filter, bool permanent)
     {
-        // var entity = await Collection.FindOneAndDeleteAsync(filter);
-        if (permanent)
+        return await FindOneAndDeleteAsync(null, filter, permanent);
+    }
+
+    public async Task<TEntity?> FindOneAndDeleteAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        bool permanent)
+    {
+        if (permanent || !SupportsSoftDelete)
         {
             return await Collection.FindOneAndDeleteAsync(filter);
         }
 
-        var updateDef = Builders<TEntity>.Update.Set(nameof(BaseEntity.DeletedAt), DateTime.UtcNow);
-        return await Collection.FindOneAndUpdateAsync(filter, updateDef, new FindOneAndUpdateOptions<TEntity>
+        var updateDef = Builders<TEntity>.Update.Set(SoftDeleteFieldName, DateTime.UtcNow);
+        var opts = new FindOneAndUpdateOptions<TEntity>
         {
             IsUpsert = false,
             ReturnDocument = ReturnDocument.After
-        });
+        };
+
+        return session != null
+            ? await Collection.FindOneAndUpdateAsync(session, filter, updateDef, opts)
+            : await Collection.FindOneAndUpdateAsync(filter, updateDef, opts);
     }
 
-    public Task<DbResult> DeleteOneAsync(string documentId)
+    public async Task<DbResult> DeleteOneAsync(string documentId, bool permanent)
     {
-        return DeleteOneAsync(documentId, permanent: false);
+        return await DeleteOneAsync(null, documentId, permanent);
     }
 
-    public Task<DbResult> DeleteOneAsync(string documentId, bool permanent)
+    public async Task<DbResult> DeleteOneAsync(IClientSessionHandle? session, string documentId, bool permanent)
     {
         AssertObjectId(documentId);
-        return DeleteAsync(FiltersBuilder<TEntity>.GetIdFilter(documentId), false, permanent);
+        return await DeleteAsync(session, FiltersBuilder<TEntity>.GetIdFilter(documentId), false, permanent);
     }
 
-    public Task<DbResult> DeleteAsync(Expression<Func<TEntity, bool>> expr)
+    public async Task<DbResult> DeleteAsync(Expression<Func<TEntity, bool>> expr, bool permanent)
     {
-        return DeleteAsync(expr, permanent: false);
+        return await DeleteAsync(null, expr, permanent);
     }
 
-    public Task<DbResult> DeleteAsync(Expression<Func<TEntity, bool>> expr, bool permanent)
+    public async Task<DbResult> DeleteAsync(IClientSessionHandle? session, Expression<Func<TEntity, bool>> expr,
+        bool permanent)
     {
-        return DeleteAsync((FilterDefinition<TEntity>) expr, true, permanent);
+        return await DeleteAsync(session, (FilterDefinition<TEntity>) expr, true, permanent);
     }
 
-    public Task<DbResult> DeleteAsync(FilterDefinition<TEntity> filter)
+    public async Task<DbResult> DeleteAsync(FilterDefinition<TEntity> filter, bool permanent)
     {
-        return DeleteAsync(filter, permanent: false);
+        return await DeleteAsync(filter, true, permanent);
     }
 
-    public Task<DbResult> DeleteAsync(FilterDefinition<TEntity> filter, bool permanent)
+    public async Task<DbResult> DeleteAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter, bool permanent)
     {
-        return DeleteAsync(filter, true, permanent);
+        return await DeleteAsync(session, filter, true, permanent);
     }
 
     public async Task<long> GenerateAutoIncrementIdAsync(long startValue)
@@ -359,71 +542,78 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
 
     protected virtual async Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(FilterDefinition<TEntity> filter, TUpdateModel payload, FindOneAndUpdateOptions<TEntity> opts)
     {
-        var update = GenerateUpdateDefinition(payload, opts.IsUpsert);
-        return await Collection.FindOneAndUpdateAsync(filter, update, opts);
+        return await FindOneAndUpdateAsync(null, filter, payload, opts);
     }
 
-    /// <summary>
-    /// Deletes one or more documents
-    /// </summary>
-    /// <param name="filter"></param>
-    /// <param name="deleteMany"></param>
-    /// <param name="permanent"></param>
-    /// <returns></returns>
+    protected virtual async Task<TEntity?> FindOneAndUpdateAsync<TUpdateModel>(IClientSessionHandle? session,
+        FilterDefinition<TEntity> filter,
+        TUpdateModel payload, FindOneAndUpdateOptions<TEntity> opts)
+    {
+        var update = GenerateUpdateDefinition(payload, opts.IsUpsert);
+
+        return session != null
+            ? await Collection.FindOneAndUpdateAsync(session, filter, update, opts)
+            : await Collection.FindOneAndUpdateAsync(filter, update, opts);
+    }
+
     protected async Task<DbResult> DeleteAsync(FilterDefinition<TEntity> filter, bool deleteMany, bool permanent)
     {
-        if (permanent)
+        return await DeleteAsync(null, filter, deleteMany, permanent);
+    }
+
+    protected async Task<DbResult> DeleteAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        bool deleteMany, bool permanent)
+    {
+        if (permanent || !SupportsSoftDelete)
         {
-            var result = deleteMany
-                ? await Collection.DeleteManyAsync(filter)
-                : await Collection.DeleteOneAsync(filter);
+            DeleteResult result;
+            if (session != null)
+            {
+                result = deleteMany
+                    ? await Collection.DeleteManyAsync(session, filter)
+                    : await Collection.DeleteOneAsync(session, filter);
+            }
+            else
+            {
+                result = deleteMany
+                    ? await Collection.DeleteManyAsync(filter)
+                    : await Collection.DeleteOneAsync(filter);
+            }
+
             return result.IsAcknowledged ? new DbResult(result.DeletedCount) : new DbResult(0);
         }
 
-        var update = Builders<TEntity>.Update.Set(doc => doc.DeletedAt, DateTime.UtcNow);
-        return await UpdateAsync(filter, update, deleteMany);
+        var update = Builders<TEntity>.Update.Set(SoftDeleteFieldName, DateTime.UtcNow);
+        return await UpdateAsync(session, filter, update, deleteMany);
     }
 
-    /// <summary>
-    /// Automatically generates UpdateDefinition and updates documents
-    /// </summary>
-    /// <param name="filter"></param>
-    /// <param name="payload"></param>
-    /// <param name="updateMany"></param>
-    /// <typeparam name="TUpdateModel"></typeparam>
-    /// <returns></returns>
-    protected virtual Task<DbResult> UpdateAsync<TUpdateModel>(FilterDefinition<TEntity> filter, TUpdateModel payload,
+    protected virtual async Task<DbResult> UpdateAsync<TUpdateModel>(FilterDefinition<TEntity> filter,
+        TUpdateModel payload, bool updateMany) where TUpdateModel : IUpdateModel
+    {
+        return await UpdateAsync(null, filter, payload, updateMany);
+    }
+
+    protected virtual async Task<DbResult> UpdateAsync<TUpdateModel>(IClientSessionHandle? session,
+        FilterDefinition<TEntity> filter,
+        TUpdateModel payload,
         bool updateMany) where TUpdateModel : IUpdateModel
     {
         var update = GenerateUpdateDefinition(payload);
-        return UpdateAsync(filter, update, updateMany);
+        return await UpdateAsync(session, filter, update, updateMany);
     }
 
-    /// <summary>
-    /// Update documents
-    /// </summary>
-    /// <param name="filter"></param>
-    /// <param name="update"></param>
-    /// <param name="updateMany"></param>
-    /// <returns></returns>
-    /// <exception cref="ArgumentNullException"></exception>
-    protected virtual async Task<DbResult> UpdateAsync(FilterDefinition<TEntity> filter, UpdateDefinition<TEntity>? update, bool updateMany)
+    protected virtual async Task<DbResult> UpdateAsync(FilterDefinition<TEntity> filter,
+        UpdateDefinition<TEntity>? update, bool updateMany)
     {
-        try
-        {
-            if (update is null) throw new ArgumentNullException(nameof(update));
+        return await UpdateAsync(null, filter, update, updateMany);
+    }
 
-            var result = updateMany
-                ? await Collection.UpdateManyAsync(filter, update)
-                : await Collection.UpdateOneAsync(filter, update);
-
-            return new DbResult(result);
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogError(ex, "UpdateAsync failed. Error={Message}", ex.Message);
-            throw;
-        }
+    protected virtual async Task<DbResult> UpdateAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        UpdateDefinition<TEntity>? update, bool updateMany)
+    {
+        return updateMany
+            ? await UpdateManyImplAsync(session, filter, update)
+            : await UpdateOneImplAsync(session, filter, update);
     }
 
     /// <summary>
@@ -488,13 +678,19 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
     /// <returns></returns>
     protected virtual string[] GetReadonlyFields()
     {
-        return new []
+        var readonlyFields = new List<string>
         {
             nameof(BaseEntity.Id),
             nameof(BaseEntity.UpdatedAt),
             nameof(BaseEntity.CreatedAt),
-            nameof(BaseEntity.DeletedAt),
         };
+
+        if (SupportsSoftDelete)
+        {
+            readonlyFields.Add(SoftDeleteFieldName);
+        }
+
+        return readonlyFields.ToArray();
     }
 
     /// <summary>
@@ -535,23 +731,35 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
 
     #region Private methods
 
-    private Task<IListViewModel<TEntity>> FindAsyncImpl(FilterDefinition<TEntity> filter, int offset, int limit, string? orderBy)
+    private Task<IListViewModel<TEntity>> FindAsyncImpl(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        int offset, int limit, string? orderBy)
     {
         var sortDef = SortDefinitionHelper.GetSortDefinition<TEntity>(orderBy);
-        return FindAsyncImpl(filter, offset, limit, sortDef);
+        return FindAsyncImpl(session, filter, offset, limit, sortDef);
     }
 
-    private async Task<IListViewModel<TEntity>> FindAsyncImpl(FilterDefinition<TEntity> filter, int offset, int limit, SortDefinition<TEntity>? sort)
+    private async Task<IListViewModel<TEntity>> FindAsyncImpl(IClientSessionHandle? session,
+        FilterDefinition<TEntity> filter, int offset, int limit, SortDefinition<TEntity>? sort)
     {
         var opts = new FindOptions<TEntity> { Skip  = offset, Limit = limit };
         // Apply sorting
         if (sort != null) opts.Sort = sort;
 
-        return await FindAsyncImpl(filter, opts);
+        return await FindAsyncImpl(session, filter, opts);
     }
 
-    private async Task<IListViewModel<TEntity>> FindAsyncImpl(FilterDefinition<TEntity> filter, FindOptions<TEntity> opts)
+    private async Task<IListViewModel<TEntity>> FindAsyncImpl(IClientSessionHandle? session,
+        FilterDefinition<TEntity> filter, FindOptions<TEntity> opts)
     {
+        if (SupportsSoftDelete)
+        {
+            var fieldName = PropertyNamingStylesHelper.ToCurrentNamingStyle(SoftDeleteFieldName);
+            filter = Builders<TEntity>.Filter.And(
+                filter,
+                Builders<TEntity>.Filter.Eq(fieldName, BsonNull.Value)
+            );
+        }
+
         if (_logger != null)
         {
             // Render filter for logging
@@ -559,7 +767,9 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
             _logger.LogInformation("FindAsyncImpl: {FilterDef}", rendered);
         }
 
-        var pageTask = Collection.FindAsync(filter, opts);
+        var pageTask = session != null
+            ? Collection.FindAsync(session, filter, opts)
+            : Collection.FindAsync(filter, opts);
 
         var tasks = new List<Task<IAsyncCursor<TEntity>>> { pageTask };
 
@@ -569,7 +779,10 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
             var nextPageOpts = new FindOptions<TEntity> { Skip  = offset + opts.Limit.Value, Limit = 1 };
             if (opts.Sort != null) nextPageOpts.Sort = opts.Sort;
 
-            var nextPageTask = Collection.FindAsync(filter, nextPageOpts);
+            var nextPageTask = session != null
+                ? Collection.FindAsync(session, filter, nextPageOpts)
+                : Collection.FindAsync(filter, nextPageOpts);
+
             tasks.Add(nextPageTask);
         }
 
@@ -584,6 +797,46 @@ public abstract class BaseRepository<TEntity> : BaseRepositoryInternal<TEntity>,
         };
 
         return result;
+    }
+
+    private async Task<DbResult> UpdateOneImplAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        UpdateDefinition<TEntity>? update)
+    {
+        try
+        {
+            if (update is null) throw new ArgumentNullException(nameof(update));
+
+            var result = session != null
+                ? await Collection.UpdateOneAsync(session, filter, update)
+                : await Collection.UpdateOneAsync(filter, update);
+
+            return new DbResult(result);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "UpdateOneAsync failed. Error={Message}", ex.Message);
+            throw;
+        }
+    }
+
+    private async Task<DbResult> UpdateManyImplAsync(IClientSessionHandle? session, FilterDefinition<TEntity> filter,
+        UpdateDefinition<TEntity>? update)
+    {
+        try
+        {
+            if (update is null) throw new ArgumentNullException(nameof(update));
+
+            var result = session != null
+                ? await Collection.UpdateManyAsync(session, filter, update)
+                : await Collection.UpdateManyAsync(filter, update);
+
+            return new DbResult(result);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "UpdateManyAsync failed. Error={Message}", ex.Message);
+            throw;
+        }
     }
 
     #endregion

--- a/ScientificBit.MongoDb/ScientificBit.MongoDb.csproj
+++ b/ScientificBit.MongoDb/ScientificBit.MongoDb.csproj
@@ -6,7 +6,8 @@
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <Nullable>enable</Nullable>
     <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
-    <Version>2.2.2</Version>
+    <Version>3.0.1</Version>
+    <PackageReleaseNotes>Brought back IMongoCollection extensions for FindOne methods </PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## v3.0.0 (Release Date: 2025-08-11)
### Changes and Fixes
* Introduced `FindOneAsync` methods variants in `BaseRepository` class to find a single document by filter or by id.
* Added `BaseRepository` method variants to accept `IClientSessionHandle` for operations that require a session.
* **DEPRECATION:** `StartSession` method in `IMongoDbContext` is now deprecated. Use `BaseRepository.StartTransactionAsync` instead.
### Breaking Changes
* Removed `DeletedAt` field from `BaseEntity` class. If you want to support
  soft deletes, you can just define a `DeletedAt` field in your entity model.
* Removed `GetDeleteAtFilter` method from `FiltersBuilder` class.